### PR TITLE
Amazon linux support

### DIFF
--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -37,7 +37,8 @@ class LanguagePack::Base
         "fedora-20"
       end
     elsif File.exists?("/etc/system-release")
-      "centos-6"
+      redhat_release = File.read("/etc/system-release").chomp
+      "centos-6" if redhat_release =~ /^Amazon Linux AMI/
     elsif File.exists?("/etc/SuSE-release")
       suse_release = File.read("/etc/SuSE-release").chomp
       case suse_release

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -36,6 +36,8 @@ class LanguagePack::Base
       when /^Fedora release 20/i
         "fedora-20"
       end
+    elsif File.exists?("/etc/system-release")
+      "centos-6"
     elsif File.exists?("/etc/SuSE-release")
       suse_release = File.read("/etc/SuSE-release").chomp
       case suse_release


### PR DESCRIPTION
It was raising `Can't find binaries for distribution. Aborting.` on amazon linux, so I made it use the `centos-6` binaries.

I don't know if this is the better way to fix this. I'm happy to hear your suggestions. 
